### PR TITLE
Add Cerebras and Groq backend support

### DIFF
--- a/cmd/aico/main.go
+++ b/cmd/aico/main.go
@@ -40,6 +40,8 @@ func run(args []string) error {
 
 			flagAPIKeyAnthropic,
 			flagAPIKeyOpenAI,
+			flagAPIKeyGroq,
+			flagAPIKeyCerebras,
 		},
 		Action: runGenerate,
 		Commands: []*cli.Command{
@@ -115,6 +117,20 @@ var (
 		Usage: "Anthropic API Key",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar(envKeyWithPrefix(appname, "anthropic_api_key")),
+		),
+	}
+	flagAPIKeyGroq = &cli.StringFlag{
+		Name:  "groq-api-key",
+		Usage: "Groq API Key",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar(envKeyWithPrefix(appname, "groq_api_key")),
+		),
+	}
+	flagAPIKeyCerebras = &cli.StringFlag{
+		Name:  "cerebras-api-key",
+		Usage: "Cerebras API Key",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar(envKeyWithPrefix(appname, "cerebras_api_key")),
 		),
 	}
 )

--- a/internal/providers/cerebras/cerebras.go
+++ b/internal/providers/cerebras/cerebras.go
@@ -1,0 +1,161 @@
+package cerebras
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+
+	"micheam.com/aico/internal/assistant"
+	"micheam.com/aico/internal/logging"
+	"micheam.com/aico/internal/providers/openai"
+)
+
+const endpoint = "https://api.cerebras.ai/v1/chat/completions"
+const ProviderName = "cerebras"
+
+// AvailableModels returns a list of available models
+func AvailableModels() []assistant.ModelDescriptor {
+	return []assistant.ModelDescriptor{
+		&Llama3_3_70B{},
+		&Llama3_1_8B{},
+	}
+}
+
+func DescribeModel(modelName string) (desc string, found bool) {
+	m, ok := selectModel(modelName)
+	if !ok {
+		return "", false
+	}
+	return m.Description(), true
+}
+
+func selectModel(modelName string) (assistant.GenerativeModel, bool) {
+	switch modelName {
+	default:
+		return nil, false
+	case "llama-3.3-70b":
+		return &Llama3_3_70B{}, true
+	case "llama-3.1-8b":
+		return &Llama3_1_8B{}, true
+	}
+}
+
+// NewGenerativeModel creates a new instance of a generative model
+func NewGenerativeModel(modelName, apiKey string) (assistant.GenerativeModel, error) {
+	switch modelName {
+	case "llama-3.3-70b":
+		return NewLlama3_3_70B(apiKey), nil
+	case "llama-3.1-8b":
+		return NewLlama3_1_8B(apiKey), nil
+	}
+	return nil, fmt.Errorf("unsupported model name: %s", modelName)
+}
+
+// buildChatRequest builds a chat request for Cerebras API (OpenAI-compatible)
+func buildChatRequest(ctx context.Context, modelName string, systemInstruction []*assistant.TextContent, msgs []*assistant.Message) (*openai.ChatRequest, error) {
+	if len(msgs) == 0 {
+		return nil, fmt.Errorf("no messages provided")
+	}
+	req := &openai.ChatRequest{
+		Model:    modelName,
+		Messages: make([]openai.Message, 0, len(msgs)+1),
+	}
+	if len(systemInstruction) > 0 {
+		for _, c := range systemInstruction {
+			req.Messages = append(req.Messages, &openai.SystemMessage{Content: c.Text})
+		}
+	}
+	for _, msg := range msgs {
+		for _, content := range msg.Contents {
+			switch v := content.(type) {
+			case *assistant.AttachmentContent:
+				content := []openai.Content{&openai.TextContent{
+					Text: v.ToText(),
+				}}
+				switch msg.Author {
+				case "user":
+					req.Messages = append(req.Messages, &openai.UserMessage{Content: content})
+				case "assistant":
+					req.Messages = append(req.Messages, &openai.AssistantMessage{Content: content})
+				}
+
+			case *assistant.TextContent:
+				switch msg.Author {
+				case "user":
+					req.Messages = append(req.Messages, &openai.UserMessage{
+						Content: []openai.Content{&openai.TextContent{Text: v.Text}},
+					})
+				case "assistant":
+					req.Messages = append(req.Messages, &openai.AssistantMessage{
+						Content: []openai.Content{&openai.TextContent{Text: v.Text}},
+					})
+				}
+
+			case *assistant.URLImageContent:
+				switch msg.Author {
+				case "user":
+					req.Messages = append(req.Messages, &openai.UserMessage{
+						Content: []openai.Content{&openai.ImageContent{URL: v.URL}},
+					})
+				case "assistant":
+					req.Messages = append(req.Messages, &openai.AssistantMessage{
+						Content: []openai.Content{&openai.ImageContent{URL: v.URL}},
+					})
+				}
+
+			default:
+				logging.LoggerFrom(ctx).Warn(fmt.Sprintf("Unsupported message content type: %T", v))
+			}
+		}
+	}
+	return req, nil
+}
+
+func toGenerateContentResponse(src *openai.ChatResponse) *assistant.GenerateContentResponse {
+	if len(src.Choices) > 0 {
+		text := src.Choices[0].Message.Content[0].(*openai.TextContent).Text
+		return &assistant.GenerateContentResponse{Content: &assistant.TextContent{Text: text}}
+	}
+	return &assistant.GenerateContentResponse{Content: nil}
+}
+
+// generateContent is a shared implementation for generating content
+func generateContent(ctx context.Context, client *openai.APIClient, modelName string, systemInstruction []*assistant.TextContent, msgs []*assistant.Message) (*assistant.GenerateContentResponse, error) {
+	req, err := buildChatRequest(ctx, modelName, systemInstruction, msgs)
+	if err != nil {
+		return nil, fmt.Errorf("build chat request: %w", err)
+	}
+	resp := new(openai.ChatResponse)
+	if err := client.DoPost(ctx, endpoint, req, resp); err != nil {
+		return nil, err
+	}
+	return toGenerateContentResponse(resp), nil
+}
+
+// generateContentStream is a shared implementation for streaming content
+func generateContentStream(ctx context.Context, client *openai.APIClient, modelName string, systemInstruction []*assistant.TextContent, msgs []*assistant.Message) (iter.Seq[*assistant.GenerateContentResponse], error) {
+	req, err := buildChatRequest(ctx, modelName, systemInstruction, msgs)
+	if err != nil {
+		return nil, fmt.Errorf("build chat request: %w", err)
+	}
+	req.Stream = true
+	iter, err := client.DoStream(ctx, endpoint, req)
+	if err != nil {
+		return nil, err
+	}
+	return func(yield func(*assistant.GenerateContentResponse) bool) {
+		for s := range iter {
+			var res *openai.ChatResponse
+			err := json.Unmarshal([]byte(s), &res)
+			if err != nil {
+				logging.LoggerFrom(ctx).Error(fmt.Sprintf("error: %v", err))
+				continue
+			}
+			delta := assistant.NewTextContent(res.Choices[0].Delta.Content)
+			if !yield(&assistant.GenerateContentResponse{Content: delta}) {
+				break
+			}
+		}
+	}, nil
+}

--- a/internal/providers/cerebras/llama3_1_8b.go
+++ b/internal/providers/cerebras/llama3_1_8b.go
@@ -1,0 +1,49 @@
+package cerebras
+
+import (
+	"context"
+	"iter"
+
+	"micheam.com/aico/internal/assistant"
+	"micheam.com/aico/internal/providers/openai"
+)
+
+type Llama3_1_8B struct {
+	systemInstruction []*assistant.TextContent
+	client            *openai.APIClient
+}
+
+var _ assistant.GenerativeModel = (*Llama3_1_8B)(nil)
+
+func NewLlama3_1_8B(apiKey string) *Llama3_1_8B {
+	return &Llama3_1_8B{
+		client: openai.NewAPIClient(apiKey),
+	}
+}
+
+func (m *Llama3_1_8B) Provider() string {
+	return ProviderName
+}
+
+func (m *Llama3_1_8B) Name() string {
+	return "llama-3.1-8b"
+}
+
+func (m *Llama3_1_8B) Description() string {
+	return `Llama 3.1 8B on Cerebras Inference delivers ultra-fast inference (~1800-2200 tokens/sec).
+A lightweight model ideal for quick tasks while maintaining Cerebras' signature speed advantage.
+Best for: simple tasks, quick Q&A, and applications requiring minimal latency.
+Reference: https://inference-docs.cerebras.ai/`
+}
+
+func (m *Llama3_1_8B) SetSystemInstruction(contents ...*assistant.TextContent) {
+	m.systemInstruction = contents
+}
+
+func (m *Llama3_1_8B) GenerateContent(ctx context.Context, msgs ...*assistant.Message) (*assistant.GenerateContentResponse, error) {
+	return generateContent(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}
+
+func (m *Llama3_1_8B) GenerateContentStream(ctx context.Context, msgs ...*assistant.Message) (iter.Seq[*assistant.GenerateContentResponse], error) {
+	return generateContentStream(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}

--- a/internal/providers/cerebras/llama3_3_70b.go
+++ b/internal/providers/cerebras/llama3_3_70b.go
@@ -1,0 +1,49 @@
+package cerebras
+
+import (
+	"context"
+	"iter"
+
+	"micheam.com/aico/internal/assistant"
+	"micheam.com/aico/internal/providers/openai"
+)
+
+type Llama3_3_70B struct {
+	systemInstruction []*assistant.TextContent
+	client            *openai.APIClient
+}
+
+var _ assistant.GenerativeModel = (*Llama3_3_70B)(nil)
+
+func NewLlama3_3_70B(apiKey string) *Llama3_3_70B {
+	return &Llama3_3_70B{
+		client: openai.NewAPIClient(apiKey),
+	}
+}
+
+func (m *Llama3_3_70B) Provider() string {
+	return ProviderName
+}
+
+func (m *Llama3_3_70B) Name() string {
+	return "llama-3.3-70b"
+}
+
+func (m *Llama3_3_70B) Description() string {
+	return `Llama 3.3 70B on Cerebras Inference delivers blazing fast inference (~2000-2500 tokens/sec).
+Cerebras' Wafer-Scale Engine eliminates memory bandwidth bottlenecks by keeping the entire model on-chip.
+Best for: tasks requiring extremely fast response times, complex reasoning, and code generation.
+Reference: https://inference-docs.cerebras.ai/`
+}
+
+func (m *Llama3_3_70B) SetSystemInstruction(contents ...*assistant.TextContent) {
+	m.systemInstruction = contents
+}
+
+func (m *Llama3_3_70B) GenerateContent(ctx context.Context, msgs ...*assistant.Message) (*assistant.GenerateContentResponse, error) {
+	return generateContent(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}
+
+func (m *Llama3_3_70B) GenerateContentStream(ctx context.Context, msgs ...*assistant.Message) (iter.Seq[*assistant.GenerateContentResponse], error) {
+	return generateContentStream(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}

--- a/internal/providers/groq/groq.go
+++ b/internal/providers/groq/groq.go
@@ -1,0 +1,166 @@
+package groq
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+
+	"micheam.com/aico/internal/assistant"
+	"micheam.com/aico/internal/logging"
+	"micheam.com/aico/internal/providers/openai"
+)
+
+const endpoint = "https://api.groq.com/openai/v1/chat/completions"
+const ProviderName = "groq"
+
+// AvailableModels returns a list of available models
+func AvailableModels() []assistant.ModelDescriptor {
+	return []assistant.ModelDescriptor{
+		&Llama3_3_70B{},
+		&Llama3_1_8B{},
+		&Mixtral8x7B{},
+	}
+}
+
+func DescribeModel(modelName string) (desc string, found bool) {
+	m, ok := selectModel(modelName)
+	if !ok {
+		return "", false
+	}
+	return m.Description(), true
+}
+
+func selectModel(modelName string) (assistant.GenerativeModel, bool) {
+	switch modelName {
+	default:
+		return nil, false
+	case "llama-3.3-70b-versatile":
+		return &Llama3_3_70B{}, true
+	case "llama-3.1-8b-instant":
+		return &Llama3_1_8B{}, true
+	case "mixtral-8x7b-32768":
+		return &Mixtral8x7B{}, true
+	}
+}
+
+// NewGenerativeModel creates a new instance of a generative model
+func NewGenerativeModel(modelName, apiKey string) (assistant.GenerativeModel, error) {
+	switch modelName {
+	case "llama-3.3-70b-versatile":
+		return NewLlama3_3_70B(apiKey), nil
+	case "llama-3.1-8b-instant":
+		return NewLlama3_1_8B(apiKey), nil
+	case "mixtral-8x7b-32768":
+		return NewMixtral8x7B(apiKey), nil
+	}
+	return nil, fmt.Errorf("unsupported model name: %s", modelName)
+}
+
+// buildChatRequest builds a chat request for Groq API (OpenAI-compatible)
+func buildChatRequest(ctx context.Context, modelName string, systemInstruction []*assistant.TextContent, msgs []*assistant.Message) (*openai.ChatRequest, error) {
+	if len(msgs) == 0 {
+		return nil, fmt.Errorf("no messages provided")
+	}
+	req := &openai.ChatRequest{
+		Model:    modelName,
+		Messages: make([]openai.Message, 0, len(msgs)+1),
+	}
+	if len(systemInstruction) > 0 {
+		for _, c := range systemInstruction {
+			req.Messages = append(req.Messages, &openai.SystemMessage{Content: c.Text})
+		}
+	}
+	for _, msg := range msgs {
+		for _, content := range msg.Contents {
+			switch v := content.(type) {
+			case *assistant.AttachmentContent:
+				content := []openai.Content{&openai.TextContent{
+					Text: v.ToText(),
+				}}
+				switch msg.Author {
+				case "user":
+					req.Messages = append(req.Messages, &openai.UserMessage{Content: content})
+				case "assistant":
+					req.Messages = append(req.Messages, &openai.AssistantMessage{Content: content})
+				}
+
+			case *assistant.TextContent:
+				switch msg.Author {
+				case "user":
+					req.Messages = append(req.Messages, &openai.UserMessage{
+						Content: []openai.Content{&openai.TextContent{Text: v.Text}},
+					})
+				case "assistant":
+					req.Messages = append(req.Messages, &openai.AssistantMessage{
+						Content: []openai.Content{&openai.TextContent{Text: v.Text}},
+					})
+				}
+
+			case *assistant.URLImageContent:
+				switch msg.Author {
+				case "user":
+					req.Messages = append(req.Messages, &openai.UserMessage{
+						Content: []openai.Content{&openai.ImageContent{URL: v.URL}},
+					})
+				case "assistant":
+					req.Messages = append(req.Messages, &openai.AssistantMessage{
+						Content: []openai.Content{&openai.ImageContent{URL: v.URL}},
+					})
+				}
+
+			default:
+				logging.LoggerFrom(ctx).Warn(fmt.Sprintf("Unsupported message content type: %T", v))
+			}
+		}
+	}
+	return req, nil
+}
+
+func toGenerateContentResponse(src *openai.ChatResponse) *assistant.GenerateContentResponse {
+	if len(src.Choices) > 0 {
+		text := src.Choices[0].Message.Content[0].(*openai.TextContent).Text
+		return &assistant.GenerateContentResponse{Content: &assistant.TextContent{Text: text}}
+	}
+	return &assistant.GenerateContentResponse{Content: nil}
+}
+
+// generateContent is a shared implementation for generating content
+func generateContent(ctx context.Context, client *openai.APIClient, modelName string, systemInstruction []*assistant.TextContent, msgs []*assistant.Message) (*assistant.GenerateContentResponse, error) {
+	req, err := buildChatRequest(ctx, modelName, systemInstruction, msgs)
+	if err != nil {
+		return nil, fmt.Errorf("build chat request: %w", err)
+	}
+	resp := new(openai.ChatResponse)
+	if err := client.DoPost(ctx, endpoint, req, resp); err != nil {
+		return nil, err
+	}
+	return toGenerateContentResponse(resp), nil
+}
+
+// generateContentStream is a shared implementation for streaming content
+func generateContentStream(ctx context.Context, client *openai.APIClient, modelName string, systemInstruction []*assistant.TextContent, msgs []*assistant.Message) (iter.Seq[*assistant.GenerateContentResponse], error) {
+	req, err := buildChatRequest(ctx, modelName, systemInstruction, msgs)
+	if err != nil {
+		return nil, fmt.Errorf("build chat request: %w", err)
+	}
+	req.Stream = true
+	iter, err := client.DoStream(ctx, endpoint, req)
+	if err != nil {
+		return nil, err
+	}
+	return func(yield func(*assistant.GenerateContentResponse) bool) {
+		for s := range iter {
+			var res *openai.ChatResponse
+			err := json.Unmarshal([]byte(s), &res)
+			if err != nil {
+				logging.LoggerFrom(ctx).Error(fmt.Sprintf("error: %v", err))
+				continue
+			}
+			delta := assistant.NewTextContent(res.Choices[0].Delta.Content)
+			if !yield(&assistant.GenerateContentResponse{Content: delta}) {
+				break
+			}
+		}
+	}, nil
+}

--- a/internal/providers/groq/llama3_1_8b.go
+++ b/internal/providers/groq/llama3_1_8b.go
@@ -1,0 +1,49 @@
+package groq
+
+import (
+	"context"
+	"iter"
+
+	"micheam.com/aico/internal/assistant"
+	"micheam.com/aico/internal/providers/openai"
+)
+
+type Llama3_1_8B struct {
+	systemInstruction []*assistant.TextContent
+	client            *openai.APIClient
+}
+
+var _ assistant.GenerativeModel = (*Llama3_1_8B)(nil)
+
+func NewLlama3_1_8B(apiKey string) *Llama3_1_8B {
+	return &Llama3_1_8B{
+		client: openai.NewAPIClient(apiKey),
+	}
+}
+
+func (m *Llama3_1_8B) Provider() string {
+	return ProviderName
+}
+
+func (m *Llama3_1_8B) Name() string {
+	return "llama-3.1-8b-instant"
+}
+
+func (m *Llama3_1_8B) Description() string {
+	return `Llama 3.1 8B Instant is a lightweight, fast model from Meta optimized for quick responses.
+Powered by Groq's LPU Inference Engine for ultra-fast inference speeds.
+Context window: 128K tokens. Best for: simple tasks, quick Q&A, and low-latency applications.
+Reference: https://console.groq.com/docs/models`
+}
+
+func (m *Llama3_1_8B) SetSystemInstruction(contents ...*assistant.TextContent) {
+	m.systemInstruction = contents
+}
+
+func (m *Llama3_1_8B) GenerateContent(ctx context.Context, msgs ...*assistant.Message) (*assistant.GenerateContentResponse, error) {
+	return generateContent(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}
+
+func (m *Llama3_1_8B) GenerateContentStream(ctx context.Context, msgs ...*assistant.Message) (iter.Seq[*assistant.GenerateContentResponse], error) {
+	return generateContentStream(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}

--- a/internal/providers/groq/llama3_3_70b.go
+++ b/internal/providers/groq/llama3_3_70b.go
@@ -1,0 +1,49 @@
+package groq
+
+import (
+	"context"
+	"iter"
+
+	"micheam.com/aico/internal/assistant"
+	"micheam.com/aico/internal/providers/openai"
+)
+
+type Llama3_3_70B struct {
+	systemInstruction []*assistant.TextContent
+	client            *openai.APIClient
+}
+
+var _ assistant.GenerativeModel = (*Llama3_3_70B)(nil)
+
+func NewLlama3_3_70B(apiKey string) *Llama3_3_70B {
+	return &Llama3_3_70B{
+		client: openai.NewAPIClient(apiKey),
+	}
+}
+
+func (m *Llama3_3_70B) Provider() string {
+	return ProviderName
+}
+
+func (m *Llama3_3_70B) Name() string {
+	return "llama-3.3-70b-versatile"
+}
+
+func (m *Llama3_3_70B) Description() string {
+	return `Llama 3.3 70B Versatile is Meta's latest large language model optimized for versatile tasks.
+Powered by Groq's LPU Inference Engine for ultra-fast inference speeds (~500-800 tokens/sec).
+Context window: 128K tokens. Best for: complex reasoning, coding, and creative tasks.
+Reference: https://console.groq.com/docs/models`
+}
+
+func (m *Llama3_3_70B) SetSystemInstruction(contents ...*assistant.TextContent) {
+	m.systemInstruction = contents
+}
+
+func (m *Llama3_3_70B) GenerateContent(ctx context.Context, msgs ...*assistant.Message) (*assistant.GenerateContentResponse, error) {
+	return generateContent(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}
+
+func (m *Llama3_3_70B) GenerateContentStream(ctx context.Context, msgs ...*assistant.Message) (iter.Seq[*assistant.GenerateContentResponse], error) {
+	return generateContentStream(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}

--- a/internal/providers/groq/mixtral_8x7b.go
+++ b/internal/providers/groq/mixtral_8x7b.go
@@ -1,0 +1,49 @@
+package groq
+
+import (
+	"context"
+	"iter"
+
+	"micheam.com/aico/internal/assistant"
+	"micheam.com/aico/internal/providers/openai"
+)
+
+type Mixtral8x7B struct {
+	systemInstruction []*assistant.TextContent
+	client            *openai.APIClient
+}
+
+var _ assistant.GenerativeModel = (*Mixtral8x7B)(nil)
+
+func NewMixtral8x7B(apiKey string) *Mixtral8x7B {
+	return &Mixtral8x7B{
+		client: openai.NewAPIClient(apiKey),
+	}
+}
+
+func (m *Mixtral8x7B) Provider() string {
+	return ProviderName
+}
+
+func (m *Mixtral8x7B) Name() string {
+	return "mixtral-8x7b-32768"
+}
+
+func (m *Mixtral8x7B) Description() string {
+	return `Mixtral 8x7B is a Mixture of Experts model from Mistral AI with excellent performance across diverse tasks.
+Powered by Groq's LPU Inference Engine for ultra-fast inference speeds.
+Context window: 32K tokens. Best for: general-purpose tasks, coding, and reasoning.
+Reference: https://console.groq.com/docs/models`
+}
+
+func (m *Mixtral8x7B) SetSystemInstruction(contents ...*assistant.TextContent) {
+	m.systemInstruction = contents
+}
+
+func (m *Mixtral8x7B) GenerateContent(ctx context.Context, msgs ...*assistant.Message) (*assistant.GenerateContentResponse, error) {
+	return generateContent(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}
+
+func (m *Mixtral8x7B) GenerateContentStream(ctx context.Context, msgs ...*assistant.Message) (iter.Seq[*assistant.GenerateContentResponse], error) {
+	return generateContentStream(ctx, m.client, m.Name(), m.systemInstruction, msgs)
+}


### PR DESCRIPTION
Add support for Groq and Cerebras high-speed inference providers:

- Groq models: llama-3.3-70b-versatile, llama-3.1-8b-instant, mixtral-8x7b-32768
- Cerebras models: llama-3.3-70b, llama-3.1-8b

Both providers use OpenAI-compatible APIs, allowing reuse of existing HTTP client infrastructure. Environment variables required:
- **AICO_GROQ_API_KEY** for Groq
- **AICO_CEREBRAS_API_KEY** for Cerebras

These providers offer significantly faster inference speeds compared to local LLM deployments (10-50x faster for Cerebras, 5-10x for Groq).