### PR TITLE
feat(cli): support provider:model qualified naming for disambiguation

### DIFF
--- a/cmd/aico/main.go
+++ b/cmd/aico/main.go
@@ -81,7 +81,7 @@ var (
 	flagModel = &cli.StringFlag{
 		Name:    "model",
 		Aliases: []string{"m"},
-		Usage:   "The model to use",
+		Usage:   "Model to use (e.g., 'gpt-4o' or 'openai:gpt-4o' for explicit provider)",
 	}
 
 	flagNoStream = &cli.BoolFlag{

--- a/cmd/aico/models_test.go
+++ b/cmd/aico/models_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseModelSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected ModelSpec
+	}{
+		{
+			name:     "simple model name",
+			input:    "gpt-4o",
+			expected: ModelSpec{Provider: "", ModelName: "gpt-4o"},
+		},
+		{
+			name:     "qualified name with provider",
+			input:    "openai:gpt-4o",
+			expected: ModelSpec{Provider: "openai", ModelName: "gpt-4o"},
+		},
+		{
+			name:     "anthropic provider",
+			input:    "anthropic:claude-haiku-4-5",
+			expected: ModelSpec{Provider: "anthropic", ModelName: "claude-haiku-4-5"},
+		},
+		{
+			name:     "groq provider",
+			input:    "groq:llama-3.3-70b-versatile",
+			expected: ModelSpec{Provider: "groq", ModelName: "llama-3.3-70b-versatile"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: ModelSpec{Provider: "", ModelName: ""},
+		},
+		{
+			name:     "colon only",
+			input:    ":",
+			expected: ModelSpec{Provider: "", ModelName: ""},
+		},
+		{
+			name:     "model with hyphen",
+			input:    "claude-sonnet-4-5",
+			expected: ModelSpec{Provider: "", ModelName: "claude-sonnet-4-5"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseModelSpec(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestQualifiedName(t *testing.T) {
+	tests := []struct {
+		provider  string
+		modelName string
+		expected  string
+	}{
+		{"openai", "gpt-4o", "openai:gpt-4o"},
+		{"anthropic", "claude-haiku-4-5", "anthropic:claude-haiku-4-5"},
+		{"groq", "llama-3.3-70b-versatile", "groq:llama-3.3-70b-versatile"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := QualifiedName(tt.provider, tt.modelName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectProviderByModelSpec(t *testing.T) {
+	tests := []struct {
+		name            string
+		spec            string
+		defaultProvider string
+		wantProvider    string
+		wantModelName   string
+		wantFound       bool
+	}{
+		{
+			name:            "explicit provider openai",
+			spec:            "openai:gpt-4o",
+			defaultProvider: "",
+			wantProvider:    "openai",
+			wantModelName:   "gpt-4o",
+			wantFound:       true,
+		},
+		{
+			name:            "explicit provider anthropic",
+			spec:            "anthropic:claude-haiku-4-5",
+			defaultProvider: "",
+			wantProvider:    "anthropic",
+			wantModelName:   "claude-haiku-4-5",
+			wantFound:       true,
+		},
+		{
+			name:            "simple name auto-detect anthropic",
+			spec:            "claude-haiku-4-5",
+			defaultProvider: "",
+			wantProvider:    "anthropic",
+			wantModelName:   "claude-haiku-4-5",
+			wantFound:       true,
+		},
+		{
+			name:            "simple name auto-detect openai",
+			spec:            "gpt-4o",
+			defaultProvider: "",
+			wantProvider:    "openai",
+			wantModelName:   "gpt-4o",
+			wantFound:       true,
+		},
+		{
+			name:            "invalid provider in spec",
+			spec:            "invalid:gpt-4o",
+			defaultProvider: "",
+			wantProvider:    "",
+			wantModelName:   "",
+			wantFound:       false,
+		},
+		{
+			name:            "unknown model",
+			spec:            "unknown-model",
+			defaultProvider: "",
+			wantProvider:    "",
+			wantModelName:   "",
+			wantFound:       false,
+		},
+		{
+			name:            "default provider used when model found",
+			spec:            "claude-haiku-4-5",
+			defaultProvider: "anthropic",
+			wantProvider:    "anthropic",
+			wantModelName:   "claude-haiku-4-5",
+			wantFound:       true,
+		},
+		{
+			name:            "default provider ignored when model not supported",
+			spec:            "gpt-4o",
+			defaultProvider: "anthropic",
+			wantProvider:    "openai",
+			wantModelName:   "gpt-4o",
+			wantFound:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, modelName, found := detectProviderByModelSpec(tt.spec, tt.defaultProvider)
+			assert.Equal(t, tt.wantProvider, provider, "provider mismatch")
+			assert.Equal(t, tt.wantModelName, modelName, "modelName mismatch")
+			assert.Equal(t, tt.wantFound, found, "found mismatch")
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,7 +44,17 @@ type Config struct {
 	// Logfile is the path to the logfile
 	logfile string `toml:"logfile"`
 
+	// DefaultProvider is the default provider to use when model name is ambiguous.
+	//
+	// When multiple providers support the same model name, this provider will be
+	// checked first. Valid values: "anthropic", "openai", "groq", "cerebras".
+	DefaultProvider string `toml:"default_provider"`
+
 	// Model is the model to use for text generation
+	//
+	// Supports two formats:
+	//   - Simple name: "claude-haiku-4-5" (uses DefaultProvider if ambiguous)
+	//   - Qualified name: "anthropic:claude-haiku-4-5" (explicit provider)
 	//
 	// If omitted, the default model for the application will be used.
 	Model string `toml:"model"`


### PR DESCRIPTION
Add support for explicit provider specification in model names to handle
cases where multiple providers support models with the same name.

Changes:
- Add default_provider field to config for preferred provider when ambiguous
- Support "provider:model" format (e.g., "groq:llama-3.3-70b-versatile")
- Update models list/describe to show qualified names
- Add shell completion for both simple and qualified names
- Add unit tests for model spec parsing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/micheam/ai-assistant-console/pull/5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
